### PR TITLE
Default to testing when running "make" within telephono/

### DIFF
--- a/telephono/Makefile
+++ b/telephono/Makefile
@@ -1,7 +1,12 @@
-.PHONY: clean
+.PHONY: all clean
+
+all: test
+
 clean:
 	rm -f telephono
 
 telephono: *.go
 	go build -o $@ cmd/telephono/main.go
 
+test:
+	go test


### PR DESCRIPTION
This PR simply sets up the Makefile to default to testing, rather than cleaning up. This is a super pedantic change since I mostly just wanted to make sure I could get the project built on my computer and I could get things merged. 