### PR TITLE
Implement common HTTP calls via basic cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 telephono/debug
 telephono/telephono
+cmd/call-buddy

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	//"../telephono"
+)
+
+func die(msg string) {
+	os.Stderr.WriteString(msg)
+	os.Exit(1)
+}
+
+func printResponse(resp *http.Response) {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(resp.Header) > 1 {
+		for key, value := range resp.Header {
+			fmt.Printf("%s: %s\n", key, strings.Trim(strings.Join(value, " "), "[]"))
+		}
+		os.Stdout.WriteString("\n")
+	}
+	os.Stdout.WriteString(string(body))
+}
+
+func main() {
+	argLen := len(os.Args[1:])
+	if argLen < 2 {
+		die("Usage: ./call-buddy <call-type> <url> [content-type]\n")
+	}
+	callType := strings.ToLower(os.Args[1])
+	url := os.Args[2]
+	contentType := "text/plain"
+	if argLen > 2 {
+		contentType = os.Args[3]
+	}
+	switch callType {
+	case "get":
+		resp, err := http.Get(url)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		printResponse(resp)
+
+	case "post":
+		resp, err := http.Post(url, contentType, os.Stdin)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		printResponse(resp)
+
+	case "head":
+		resp, err := http.Head(url)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		printResponse(resp)
+
+	case "delete":
+		req, err := http.NewRequest("DELETE", url, nil)
+		if err != nil {
+			log.Fatal(err)
+		}
+		req.Header.Add("Connection", "close")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		printResponse(resp)
+
+	case "put":
+		req, err := http.NewRequest("PUT", url, os.Stdin)
+		if err != nil {
+			log.Fatal(err)
+		}
+		req.Header.Add("Connection", "close")
+		req.Header.Add("Content-type", contentType)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer resp.Body.Close()
+		printResponse(resp)
+
+	default:
+		die("Invalid <call-type> given.\n")
+	}
+}


### PR DESCRIPTION
The basic usage is `./call-buddy <call-type> <url> [content-type]`, where the call-type is either `POST`, `GET`, `HEAD`, `PUT` or `DELETE`. If the call-type is not a `GET`, `HEAD` or `DELETE` then stdin is used as the request body and the content-type is text/plain, unless specified with the optional content-type argument.

This is obviously a long way away from the UI and the full functionality of call buddy, but the code showcases the basic code for making HTTP calls.

@alexmherrmann if you have any suggestions as far as more idiomatic go code or mistakes in my go code, let me know!

As far as others go, general feedback would be great!
