### PR TITLE
Move call-buddy arch building to new build-arch.sh script and arch.txt

### DIFF
--- a/arch.txt
+++ b/arch.txt
@@ -1,0 +1,48 @@
+# Contains Operating Systems/Architectures to build. Feel free to add/remove.
+#
+# Note that the following syntax is
+# GOOS GOARCH
+# GOOS GOARCH [ALIAS1]
+# GOOS GOARCH [ALIAS2]
+# ...
+#
+# ^ The plain "GOOS ARCH" is used in the non-symbolic name (i.e. creates a
+#   compiled binary) and the aliases are just symbolic links to the
+#   corresponding non-symbolic name
+#
+# Note: We need the ALIAS because we use the following internally to figure
+#       out the OS and architecture when launching call-buddy to hosts on
+#       UNIXes:
+#
+# $ uname -s -m | tr ' ' '-' | tr '[:upper:]' '[:lower:]'
+#
+# Most uname aliases pulled from, others hand picked:
+# https://en.wikipedia.org/wiki/Uname
+#
+# Go's supported GOOS/GOARCH found at:
+# https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63
+#
+linux 386
+linux 386 i386
+linux amd64
+linux amd64 x86_64
+linux arm
+# Go only supports armv5+
+linux arm armv5
+linux arm armv6
+# Raspberry Pi B
+linux arm armv6l
+# Raspberry Pi 2B
+linux arm armhf
+linux arm armv7
+# Raspberry Pi 4
+linux arm armv7l
+linux arm64
+linux arm64 armv8
+darwin amd64
+darwin amd64 x86_64
+freebsd amd64
+freebsd amd64 x86_64
+freebsd 386
+freebsd 386 i386
+# Presumably Windows should be here, but don't have official support yet

--- a/build-arch.sh
+++ b/build-arch.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Builds the given $1 target based on ${@:2} for architectures in arch.txt.
+basedir=`dirname "$0"`
+target="$1"
+shift
+cat "$basedir/arch.txt" \
+    | grep -v '#' \
+    | awk 'NF = 2 { printf "env GOOS=%s GOARCH=%s go build -o build/%s-%s/'"$target"' '"$@"'\n", $1, $2, $1, $2 }' \
+    | sort | uniq \
+    | sh
+
+cat "$basedir/arch.txt" \
+    | grep -v '^#' \
+    | awk 'NF > 2 { printf "ln -sf build/%s-%s build/%s-%s\n", $1, $2, $1, $3 }' \
+    | sh

--- a/telephono-ui/Makefile
+++ b/telephono-ui/Makefile
@@ -10,23 +10,4 @@ call-buddy: cmd/call-buddy/*.go
 	go build -o $@ $^
 
 call-buddy-archs: cmd/call-buddy/*.go
-	# Note that the following build names are different from the corresponding
-	# GOOS-GOARCH name because we rely on the names from the following cmd:
-	# "uname -s -m | tr ' ' '-' | tr '[:upper:]' '[:lower:]'"
-	# which is used internally to determine the arch and os.
-	#
-	# Building for most servers
-	env GOOS=linux GOARCH=386 go build -o build/linux-i386/call-buddy $^
-	env GOOS=linux GOARCH=amd64 go build -o build/linux-x86_64/call-buddy $^
-	ln -sf linux-x86_64 build/linux-amd64
-	# Building for the Raspberry Pi!
-	env GOOS=linux GOARCH=arm go build -o build/linux-arm/call-buddy $^
-	ln -sf linux-arm build/linux-armv7l
-	ln -sf linux-arm build/linux-armhf
-	env GOOS=linux GOARCH=arm64 go build -o build/linux-arm64/call-buddy $^
-	ln -sf linux-arm64 build/linux-armv8
-	ln -sf linux-arm64 build/linux-aarch64
-	# Building for MacOS
-	env GOOS=darwin GOARCH=386 go build -o build/darwin-i386/call-buddy $^
-	env GOOS=darwin GOARCH=amd64 go build -o build/darwin-x86_64/call-buddy $^
-	ln -sf darwin-x86_64 build/darwin-amd64
+	../build-arch.sh call-buddy $^


### PR DESCRIPTION
With the `launchpad` utility the idea is that any box connected via SSH
can instantly run call-buddy, regardless of whether it's installed on
that box or regardless of the architecture. Because we want to run on
most, if not all common architectures, this requires that architecture
specific binaries be compiled and installed ahead of time, lest we want
to require users to always have a go compiler handy at run time. We
currently do this in the `telephono-ui/Makefile`, but if a user or
developer wants to compile to a non-standard architecture, it's not
obvious nor documented how this would be done.

To fix this, the build-arch.sh script was created to basically enumerate
though the architectures defined in arch.txt. Having this present in the
root directory also makes it easier and more obvious to users/developers
on how to add a architecture, and correspondingly, documentation has been
written on how to do so.