### PR TITLE
Revamp building and installation of call-buddy and launchpad binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SUBDIRS := telephono telephono-ui launchpad
+export prefix="/usr"
 
 .PHONY: all $(SUBDIRS)
 
@@ -15,3 +16,9 @@ telephono-ui:
 
 launchpad:
 	$(MAKE) -C launchpad all
+
+install:
+	@for d in $(SUBDIRS); do $(MAKE) -C $$d install; done
+
+uninstall:
+	@for d in $(SUBDIRS); do $(MAKE) -C $$d uninstall; done

--- a/arch.txt
+++ b/arch.txt
@@ -1,0 +1,48 @@
+# Contains Operating Systems/Architectures to build. Feel free to add/remove.
+#
+# Note that the following syntax is
+# GOOS GOARCH
+# GOOS GOARCH [ALIAS1]
+# GOOS GOARCH [ALIAS2]
+# ...
+#
+# ^ The plain "GOOS ARCH" is used in the non-symbolic name (i.e. creates a
+#   compiled binary) and the aliases are just symbolic links to the
+#   corresponding non-symbolic name
+#
+# Note: We need the ALIAS because we use the following internally to figure
+#       out the OS and architecture when launching call-buddy to hosts on
+#       UNIXes:
+#
+# $ uname -s -m | tr ' ' '-' | tr '[:upper:]' '[:lower:]'
+#
+# Most uname aliases pulled from, others hand picked:
+# https://en.wikipedia.org/wiki/Uname
+#
+# Go's supported GOOS/GOARCH found at:
+# https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63
+#
+linux 386
+linux 386 i386
+linux amd64
+linux amd64 x86_64
+linux arm
+# Go only supports armv5+
+linux arm armv5
+linux arm armv6
+# Raspberry Pi B
+linux arm armv6l
+# Raspberry Pi 2B
+linux arm armhf
+linux arm armv7
+# Raspberry Pi 4
+linux arm armv7l
+linux arm64
+linux arm64 armv8
+darwin amd64
+darwin amd64 x86_64
+freebsd amd64
+freebsd amd64 x86_64
+freebsd 386
+freebsd 386 i386
+# Presumably Windows should be here, but don't have official support yet

--- a/build-arch.sh
+++ b/build-arch.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Builds the given $1 target based on ${@:2} for architectures in arch.txt.
+basedir=`dirname "$0"`
+target="$1"
+shift
+cat "$basedir/arch.txt" \
+    | grep -v '#' \
+    | awk 'NF = 2 { printf "env GOOS=%s GOARCH=%s go build -o build/%s-%s/'"$target"' '"$@"'\n", $1, $2, $1, $2 }' \
+    | sort | uniq \
+    | sh
+
+cat "$basedir/arch.txt" \
+    | grep -v '^#' \
+    | awk 'NF > 2 { printf "ln -sf build/%s-%s build/%s-%s\n", $1, $2, $1, $3 }' \
+    | sh

--- a/build-arch.sh
+++ b/build-arch.sh
@@ -4,7 +4,7 @@ basedir=`dirname "$0"`
 target="$1"
 shift
 cat "$basedir/arch.txt" \
-    | grep -v '#' \
+    | grep -v '^#' \
     | awk 'NF = 2 { printf "env GOOS=%s GOARCH=%s go build -o build/%s-%s/'"$target"' '"$@"'\n", $1, $2, $1, $2 }' \
     | sort | uniq \
     | sh

--- a/launchpad/Makefile
+++ b/launchpad/Makefile
@@ -7,3 +7,6 @@ clean:
 
 launchpad: cmd/launchpad/*.go
 	go build -o $@ $^
+
+install: launchpad
+	cp launchpad $(prefix)/bin/

--- a/telephono-ui/Makefile
+++ b/telephono-ui/Makefile
@@ -10,23 +10,4 @@ call-buddy: cmd/call-buddy/*.go
 	go build -o $@ $^
 
 call-buddy-archs: cmd/call-buddy/*.go
-	# Note that the following build names are different from the corresponding
-	# GOOS-GOARCH name because we rely on the names from the following cmd:
-	# "uname -s -m | tr ' ' '-' | tr '[:upper:]' '[:lower:]'"
-	# which is used internally to determine the arch and os.
-	#
-	# Building for most servers
-	env GOOS=linux GOARCH=386 go build -o build/linux-i386/call-buddy $^
-	env GOOS=linux GOARCH=amd64 go build -o build/linux-x86_64/call-buddy $^
-	ln -sf linux-x86_64 build/linux-amd64
-	# Building for the Raspberry Pi!
-	env GOOS=linux GOARCH=arm go build -o build/linux-arm/call-buddy $^
-	ln -sf linux-arm build/linux-armv7l
-	ln -sf linux-arm build/linux-armhf
-	env GOOS=linux GOARCH=arm64 go build -o build/linux-arm64/call-buddy $^
-	ln -sf linux-arm64 build/linux-armv8
-	ln -sf linux-arm64 build/linux-aarch64
-	# Building for MacOS
-	env GOOS=darwin GOARCH=386 go build -o build/darwin-i386/call-buddy $^
-	env GOOS=darwin GOARCH=amd64 go build -o build/darwin-x86_64/call-buddy $^
-	ln -sf darwin-x86_64 build/darwin-amd64
+	../build-arch.sh call-buddy $^

--- a/telephono-ui/Makefile
+++ b/telephono-ui/Makefile
@@ -11,3 +11,13 @@ call-buddy: cmd/call-buddy/*.go
 
 call-buddy-archs: cmd/call-buddy/*.go
 	../build-arch.sh call-buddy $^
+
+install: call-buddy call-buddy-archs
+	mkdir -p $(prefix)/bin
+	cp call-buddy $(prefix)/bin/
+	mkdir -p $(prefix)/lib/call-buddy/
+	cp -RP build/* $(prefix)/lib/call-buddy
+
+uninstall: all
+	rm $(prefix)/bin/call-buddy
+	rm -r $(prefix)/lib/call-buddy/


### PR DESCRIPTION
This MR creates a two new targets for the Makefiles: `install` and `uninstall`, which do what you expect them to do. I default to assuming you want to install stuff to `/usr`, but you can override this by adding `prefix=<prefix>/` to your `make install` command:

```bash
make  # Build it
make install prefix=/opt  # Install it
```

This PR also adds the ability to specify which extra `call-buddy` binary architectures to build for. There's a pretty sensible list in `arch.txt` that should cover most cases, but users can go ahead and modify that file if they want to build for some of the more uncommon architecture and OS combinations.

I'll note that the syntax for `arch.txt` is pretty weird since the mapping between Golang's `$GOOS-$GOARCH` is not the same as you can find out via `uname -s -m` (or well-known files across UNIX systems) and thus you have to have some mapping between the two. I've heavily documented this syntax as a result, feel free to read the file for more details on why and if it doesn't make sense let me know. Perhaps someone can come up with a better scheme too.