### PR TITLE
Search for call-buddy binaries in launchpad, rather than relying on hardcoded paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ launchpad:
 
 install:
 	@for d in $(SUBDIRS); do $(MAKE) -C $$d install; done
+	@echo
+	@echo "Warning: You need an TCB_ARCH_DIR environment variable pointing to "$(realprefix)/lib/call-buddy" for the 'launchpad' utility to work:"
+	@if [ `uname -s` == "Darwin" ]; then \
+	    echo "echo 'export TCB_ARCH_DIR=\"$(realprefix)/lib/call-buddy\"' >> ~/.bash_profile"; \
+	else \
+	    echo 'export TCB_ARCH_DIR=\"$(realprefix)/lib/call-buddy\"' >> ~/.bashrc; \
+	fi
 
 uninstall:
 	@for d in $(SUBDIRS); do $(MAKE) -C $$d uninstall; done

--- a/build-arch.sh
+++ b/build-arch.sh
@@ -11,5 +11,5 @@ cat "$basedir/arch.txt" \
 
 cat "$basedir/arch.txt" \
     | grep -v '^#' \
-    | awk 'NF > 2 { printf "ln -sf build/%s-%s build/%s-%s\n", $1, $2, $1, $3 }' \
+    | awk 'NF > 2 { printf "ln -sf %s-%s/ build/%s-%s\n", $1, $2, $1, $3 }' \
     | sh

--- a/launchpad/cmd/launchpad/main.go
+++ b/launchpad/cmd/launchpad/main.go
@@ -381,12 +381,15 @@ func remoteRun(target, arch *string, args []string) {
 }
 
 func localRun(args []string) {
-	localCallBuddyPath := "../telephono-ui/call-buddy"
+	callBuddyPath, err := exec.LookPath("call-buddy")
+	if err != nil {
+		log.Fatal("Could not find call-buddy in $PATH!")
+	}
 	// We don't have a full argv here since we are missing arg 0: the executable name
-	argsWithArg0 := append([]string{filepath.Base(localCallBuddyPath)}, args...)
+	argv := append([]string{callBuddyPath}, args...)
 	exe := &exec.Cmd{
-		Path:   localCallBuddyPath,
-		Args:   argsWithArg0,
+		Path:   callBuddyPath,
+		Args:   argv,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 		Stdin:  os.Stdin,

--- a/launchpad/cmd/launchpad/main.go
+++ b/launchpad/cmd/launchpad/main.go
@@ -347,8 +347,10 @@ func remoteRun(target, arch *string, args []string) {
 		arch = &detectedArch
 	}
 
+	localCallBuddyPath := lookupCallBuddyPath(*arch)
 	remoteCallBuddyPath := remoteHomeDir + "/.call-buddy/call-buddy"
 	remoteCallBuddyDir := filepath.Dir(remoteCallBuddyPath)
+
 	log.Printf("Spawning off remote syncing client on %s\n", hostname)
 	syncingClient, err := spawnRemoteSyncing(client, remoteCallBuddyDir)
 	if err != nil {
@@ -356,15 +358,13 @@ func remoteRun(target, arch *string, args []string) {
 		log.Fatal("Failed to spawn off remote syncing")
 	}
 
-	cwd, _ := os.Getwd()
-	localCallBuddyPath := filepath.Clean(cwd + "/../telephono-ui/build/" + *arch + "/call-buddy")
 	log.Printf("Syncing call-buddy from %s to remote client at %s@%s:%s\n", localCallBuddyPath, username, hostname, remoteCallBuddyPath)
 	err = bootstrapCallBuddy(syncingClient.sftpClient, localCallBuddyPath, remoteCallBuddyPath)
 	bootstrapped := err == nil
 
 	session, err := getPty(client)
 	if err != nil {
-		log.Fatalf("Failed to get pty on %s@%s\n")
+		log.Fatalf("Failed to get pty on %s@%s\n", username, hostname)
 	}
 
 	session.Run(remoteCallBuddyPath + " " + strings.Join(args, " "))
@@ -378,6 +378,48 @@ func remoteRun(target, arch *string, args []string) {
 	waitGroup.Wait()
 	session.Close()
 	cleanupRemoteSyncing(syncingClient)
+}
+
+func fileExists(fpath string) bool {
+	_, err := os.Stat(fpath)
+	return err == nil || !os.IsNotExist(err)
+}
+
+func lookupCallBuddyPath(arch string) string {
+	fatalstr := "Could not find " + arch + " call-buddy binary"
+
+	// First try looking for the environment variable
+	if archDir := os.Getenv("TCB_ARCH_DIR"); archDir != "" {
+		potPath := filepath.Join(archDir, arch, "call-buddy")
+		if fileExists(potPath) {
+			return potPath
+		}
+		fatalstr += " in $TCB_ARCH_DIR/ (" + archDir + ")"
+	} else {
+		fatalstr += " via $TCB_ARCH_DIR"
+	}
+
+	// If that fails we'll use the /lib of the prefix of where call-buddy
+	// is since it's most likely there.
+	callBuddyPath, err := exec.LookPath("call-buddy")
+	if err == nil {
+		binDir := filepath.Dir(callBuddyPath) // .../bin/
+		prefix := filepath.Dir(binDir)        // .../
+		basePotPath := filepath.Join(prefix, "lib", "call-buddy")
+		potPath := filepath.Join(basePotPath, arch, "call-buddy")
+		if fileExists(potPath) {
+			return potPath
+		}
+		fatalstr += " nor in " + basePotPath
+	} else {
+		fatalstr += " nor could call-buddy be found"
+	}
+
+	// Otherwise, maybe we could search through the $PATH, but that feels
+	// a bit hacky, plus we have to deal with the can of worms of symbolic
+	// links and the like
+	log.Fatal(fatalstr)
+	return ""
 }
 
 func localRun(args []string) {


### PR DESCRIPTION
This MR makes the `launchpad` utility search for either the local `call-buddy` binary in `$PATH` if running locally or if running remotely, looking in `$TCB_ARCH_DIR` or in `$(which call-buddy | xargs dirname | xargs dirname)/lib/call-buddy/` (essentially `../lib/call-buddy` relative to where `call-buddy` is installed). See the commit messages for more details.