### PR TITLE
Resolve user defined prefix in Makefile to abspath to prevent issues where prefix is relative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SUBDIRS := telephono telephono-ui launchpad
 export prefix="/usr"
+export realprefix=$(abspath $(prefix))
 
 .PHONY: all $(SUBDIRS)
 

--- a/launchpad/Makefile
+++ b/launchpad/Makefile
@@ -9,4 +9,4 @@ launchpad: cmd/launchpad/*.go
 	go build -o $@ $^
 
 install: launchpad
-	cp launchpad $(prefix)/bin/
+	cp launchpad $(realprefix)/bin/

--- a/telephono-ui/Makefile
+++ b/telephono-ui/Makefile
@@ -13,11 +13,11 @@ call-buddy-archs: cmd/call-buddy/*.go
 	../build-arch.sh call-buddy $^
 
 install: call-buddy call-buddy-archs
-	mkdir -p $(prefix)/bin
-	cp call-buddy $(prefix)/bin/
-	mkdir -p $(prefix)/lib/call-buddy/
-	cp -RP build/* $(prefix)/lib/call-buddy
+	mkdir -p $(realprefix)/bin
+	cp call-buddy $(realprefix)/bin/
+	mkdir -p $(realprefix)/lib/call-buddy/
+	cp -RP build/* $(realprefix)/lib/call-buddy
 
 uninstall: all
-	rm $(prefix)/bin/call-buddy
-	rm -r $(prefix)/lib/call-buddy/
+	rm $(realprefix)/bin/call-buddy
+	rm -r $(realprefix)/lib/call-buddy/


### PR DESCRIPTION
If you were to do `make install prefix=../usr/local`, the result would
be an error, rather than install to `../usr/local` since that location
would later be interpreted as relative to `launchpad/`, `telephono-ui/` and
`telephono/`, rather than the base directory when those Makefiles are
called.

The fix for this is to simply make the given `prefix="..."` variable an
absolute path so the prefix path is the same when in subdirectories.