### PR TITLE
Partly hint selected history entry in view

### DIFF
--- a/telephono/telephono_state_history.go
+++ b/telephono/telephono_state_history.go
@@ -44,21 +44,11 @@ func (wholeHistory *CallBuddyHistory) GetSimpleWholeHistoryReport() string {
 	return buffer.String()
 }
 
-// ^ Same comment probably applies here -Dylan
-func (wholeHistory *CallBuddyHistory) GetNthCommand(n int) (string, error) {
+func (wholeHistory *CallBuddyHistory) Get(n int) (HistoricalCall, error) {
 	if n < 0 || n > len(wholeHistory.callsFromCurrentSession)-1 {
-		return "", fmt.Errorf("No command at pos %d", n)
+		return HistoricalCall{}, fmt.Errorf("No history at pos %d", n)
 	}
-	call := wholeHistory.callsFromCurrentSession[n]
-
-	// {method} {request URL} [content-type]
-	cmd := fmt.Sprintf("%s %s", call.Request.Method, call.Request.URL)
-
-	// Golang's net.http.Header is a map[string][]string for some reason
-	if len(call.Request.Header["Content-type"]) > 0 {
-		cmd += " " + call.Request.Header["Content-type"][0]
-	}
-	return cmd, nil
+	return wholeHistory.callsFromCurrentSession[n], nil
 }
 
 func (wholeHistory *CallBuddyHistory) Size() int {


### PR DESCRIPTION
When hinting, it's possible for the user to 'cancel' the operation
by hitting tab or shift-tab so a new struct to store the backup state of
the view was created. This struct has two main methods: store and
restore which take in the GUI and do what you expect them to do. That
with a new updateViewsWithCall() function that takes in a HistoricalCall
and updates all the necessary views in one go is the core logic done
here.

There is however another necessary change I had to make in telephono
which isn't ideal. I had to make 'request' and 'response' in the
HistoricalCall public since we need the internal state (http.Response) to
actually do anything useful without creating a very specific and
complicated function in telephono_state_history that would ultimately
have to tie to the GUI/View stuff. Also, in order to get a
HistoricalCall out of the history I created a Get() CallBuddyHistory
function.

Furthermore, this commit actually doesn't work. It doesn't work because
the http.Response.Body of the response from call() is empty once you
make more than one call (go overrides it). This obviously makes it so we
don't have a history of response bodies and cannot hint at what it is.
This is a larger problem to tackle since it requires creating a new
struct in telephono to store response info.