### PR TITLE
Minor thangs

### DIFF
--- a/telephono-ui/cmd/call-buddy/main.go
+++ b/telephono-ui/cmd/call-buddy/main.go
@@ -280,6 +280,8 @@ func switchNextView(g *gocui.Gui, v *gocui.View) error {
 	case RSP_BODY:
 		// -> command line
 		setView(g, CMD_LINE_VIEW, CMD_LINE)
+	case HIST_BODY:
+		setView(g, HIST_VIEW, HIST_BODY)
 	default:
 		log.Panicf("Got to a unknown view! %d\n", currView)
 	}
@@ -313,7 +315,12 @@ func switchPrevView(g *gocui.Gui, v *gocui.View) error {
 }
 
 func setHistView(g *gocui.Gui, v *gocui.View) error {
-	setView(g, HIST_VIEW, HIST_BODY)
+	// FIXME: POSSIBLY SWITCH BACK TO LAST SELECTED VIEW?
+	if currView == HIST_BODY {
+		setView(g, CMD_LINE_VIEW, CMD_LINE)
+	} else {
+		setView(g, HIST_VIEW, HIST_BODY)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Got small bug fixed where if you pressed tab while in history it crashed the program.

Ctrl-Y now goes back to the CMD line if you press it while in the history view as well (giving users an option to not select something in history and just escape it)