### PR TITLE
Replace internal http.Request/Response structs with custom ones

### DIFF
--- a/telephono/method_test.go
+++ b/telephono/method_test.go
@@ -13,7 +13,7 @@ func TestHttpMethodAsString(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.shouldbe, func(t *testing.T) {
-			if test.method.asMethodString() != test.shouldbe {
+			if test.method.String() != test.shouldbe {
 				t.Error("asString Method didn't return correctly")
 			}
 		})

--- a/telephono/telephono_state.go
+++ b/telephono/telephono_state.go
@@ -2,7 +2,9 @@ package telephono
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 )
 
 //here is a test comment to make sure i am editing and commiting correctly - coop diddy
@@ -17,8 +19,29 @@ const (
 	Head              = "HEAD"
 )
 
-func (m HttpMethod) asMethodString() string {
+func AllHttpMethods() []HttpMethod {
+	return []HttpMethod{Post, Get, Put, Delete, Head}
+}
+
+func (m HttpMethod) String() string {
 	return string(m)
+}
+
+func toHttpMethod(method string) (HttpMethod, error) {
+	methodUpper := strings.ToUpper(method)
+	switch methodUpper {
+	case "POST":
+		return Post, nil
+	case "GET":
+		return Get, nil
+	case "PUT":
+		return Put, nil
+	case "DELETE":
+		return Delete, nil
+	case "HEAD":
+		return Head, nil
+	}
+	return "", errors.New("No such HTTP method " + method)
 }
 
 type expandable interface {

--- a/telephono/telephono_state_call.go
+++ b/telephono/telephono_state_call.go
@@ -1,0 +1,73 @@
+package telephono
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type (
+	// Override Go's http.Request with permanent body and only
+	// the things we care about
+	Request struct {
+		Method HttpMethod
+		URL    string
+		Header http.Header
+		Body   []byte
+	}
+
+	// Override Go's http.Response with permanent body and only
+	// the things we care about
+	Response struct {
+		Status     string
+		StatusCode int
+		Header     http.Header
+		Body       []byte
+	}
+)
+
+func (request *Request) Populate(httpRequest *http.Request) error {
+	method, err := toHttpMethod(httpRequest.Method)
+	if err != nil {
+		return err
+	}
+	request.Method = method
+	request.URL = httpRequest.URL.String()
+	request.Header = httpRequest.Header
+
+	request.Body = []byte("")
+	bodyBuffer, err := ioutil.ReadAll(httpRequest.Body)
+	if err != nil {
+		return err
+	}
+	httpRequest.Body.Close()
+	request.Body = bodyBuffer
+	return nil
+}
+
+func (response *Response) Populate(httpResponse *http.Response) error {
+	response.Status = httpResponse.Status
+	response.StatusCode = httpResponse.StatusCode
+	response.Header = httpResponse.Header
+
+	response.Body = []byte("")
+	bodyBuffer, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		return err
+	}
+	httpResponse.Body.Close()
+	response.Body = bodyBuffer
+	return nil
+}
+
+func (response *Response) String() (result string) {
+	if len(response.Header) > 1 {
+		for key, value := range response.Header {
+			result += fmt.Sprintf("%s: %s\n", key, strings.Trim(strings.Join(value, " "), "[]"))
+		}
+		result += "\n"
+	}
+	result += string(response.Body)
+	return
+}

--- a/telephono/telephono_state_call_test.go
+++ b/telephono/telephono_state_call_test.go
@@ -1,0 +1,3 @@
+package telephono_test
+
+import ()

--- a/telephono/telephono_state_history.go
+++ b/telephono/telephono_state_history.go
@@ -2,7 +2,6 @@ package telephono
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -12,8 +11,8 @@ type (
 	//}
 
 	HistoricalCall struct {
-		request  http.Request
-		response http.Response
+		Response Response
+		Request  Request
 	}
 
 	CallBuddyHistory struct {
@@ -21,17 +20,14 @@ type (
 	}
 )
 
-func (wholeHistory *CallBuddyHistory) AddFinishedCall(input CallResponse) {
-	wholeHistory.callsFromCurrentSession = append(wholeHistory.callsFromCurrentSession, HistoricalCall{
-		request:  *(input.Request),
-		response: *input,
-	})
+func (wholeHistory *CallBuddyHistory) AddFinishedCall(call HistoricalCall) {
+	wholeHistory.callsFromCurrentSession = append(wholeHistory.callsFromCurrentSession, call)
 }
 
 // GetSimpleReport generates simple string report that gives info about the request/response
 func (theCall HistoricalCall) GetSimpleReport() string {
 	// {method} {request URL}: {response code} [content length]
-	return fmt.Sprintf("%8s %-50s: [%3d] [%5d] bytes", theCall.request.Method, theCall.request.URL.String(), theCall.response.StatusCode, theCall.response.ContentLength)
+	return fmt.Sprintf("%8s %-50s: [%3d] [%5d] bytes", theCall.Request.Method, theCall.Request.URL, theCall.Response.StatusCode, len(theCall.Response.Body))
 }
 
 // TODO AH: May not be this method's concern, but this is hacky and will get big quickly
@@ -56,11 +52,11 @@ func (wholeHistory *CallBuddyHistory) GetNthCommand(n int) (string, error) {
 	call := wholeHistory.callsFromCurrentSession[n]
 
 	// {method} {request URL} [content-type]
-	cmd := fmt.Sprintf("%s %s", call.request.Method, call.request.URL.String())
+	cmd := fmt.Sprintf("%s %s", call.Request.Method, call.Request.URL)
 
 	// Golang's net.http.Header is a map[string][]string for some reason
-	if len(call.request.Header["Content-type"]) > 0 {
-		cmd += " " + call.request.Header["Content-type"][0]
+	if len(call.Request.Header["Content-type"]) > 0 {
+		cmd += " " + call.Request.Header["Content-type"][0]
 	}
 	return cmd, nil
 }


### PR DESCRIPTION
This allows us to have better control over the body, which normally is
a io.ReaderCloser which presents problems when trying to read things
more than once. This problem prevented PR #37 (which allowed for hinting
of history entries) from working.

It also enables us to create custom methods on those new structs such as
the String() method in the response, further separating the logic
between the TUI and the store.