### PR TITLE
Re-enable arrow keys in editable views

### DIFF
--- a/telephono-ui/cmd/call-buddy/main.go
+++ b/telephono-ui/cmd/call-buddy/main.go
@@ -59,17 +59,11 @@ func (editor *TCBEditor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.M
 		return
 	}
 
-	switch {
-	case ch != 0 && mod == 0:
-		v.EditWrite(ch)
-	case key == gocui.KeySpace:
-		v.EditWrite(' ')
-	case key == gocui.KeyBackspace || key == gocui.KeyBackspace2:
-		v.EditDelete(true)
-	case ch == '[' && mod == gocui.ModAlt:
+	if ch == '[' && mod == gocui.ModAlt {
 		editor.expectKeyModifier = true
+		return
 	}
-	// FIXME Dylan: Call the parent gocui.Editor.Edit!
+	gocui.DefaultEditor.Edit(v, key, ch, mod)
 }
 
 // ViewState Which view is active


### PR DESCRIPTION
Apparently I messed up with the custom editor that enabled shift-tab and
didn't call the parent edit function, which prevented arrow keys from
working. Apparently we don't actually have to implement them like we
previously thought!